### PR TITLE
added to supress known potential GCC warnings

### DIFF
--- a/darknet_ros/src/data.c
+++ b/darknet_ros/src/data.c
@@ -1,4 +1,3 @@
-#pragma GCC diagnostic ignored "-Wunused-result"
 #include "data.h"
 #include "utils.h"
 #include "image.h"
@@ -956,12 +955,13 @@ data load_cifar10_data(char *filename)
     if(!fp) file_error(filename);
     for(i = 0; i < 10000; ++i){
         unsigned char bytes[3073];
-        fread(bytes, 1, 3073, fp);
+       if( fread(bytes, 1, 3073, fp)==1){
         int class = bytes[0];
         y.vals[i][class] = 1;
         for(j = 0; j < X.cols; ++j){
             X.vals[i][j] = (double)bytes[j+1];
         }
+    }
     }
     //translate_data_rows(d, -128);
     scale_data_rows(d, 1./255);
@@ -1020,12 +1020,13 @@ data load_all_cifar10()
         if(!fp) file_error(buff);
         for(i = 0; i < 10000; ++i){
             unsigned char bytes[3073];
-            fread(bytes, 1, 3073, fp);
+           if( fread(bytes, 1, 3073, fp)==1){
             int class = bytes[0];
             y.vals[i+b*10000][class] = 1;
             for(j = 0; j < X.cols; ++j){
                 X.vals[i+b*10000][j] = (double)bytes[j+1];
             }
+        }
         }
         fclose(fp);
     }

--- a/darknet_ros/src/data.c
+++ b/darknet_ros/src/data.c
@@ -1,3 +1,4 @@
+#pragma GCC diagnostic ignored "-Wunused-result"
 #include "data.h"
 #include "utils.h"
 #include "image.h"

--- a/darknet_ros/src/data.c
+++ b/darknet_ros/src/data.c
@@ -955,7 +955,7 @@ data load_cifar10_data(char *filename)
     if(!fp) file_error(filename);
     for(i = 0; i < 10000; ++i){
         unsigned char bytes[3073];
-       if( fread(bytes, 1, 3073, fp)==1){
+        if( fread(bytes, 1, 3073, fp)==1){
         int class = bytes[0];
         y.vals[i][class] = 1;
         for(j = 0; j < X.cols; ++j){
@@ -1020,7 +1020,7 @@ data load_all_cifar10()
         if(!fp) file_error(buff);
         for(i = 0; i < 10000; ++i){
             unsigned char bytes[3073];
-           if( fread(bytes, 1, 3073, fp)==1){
+            if( fread(bytes, 1, 3073, fp)==1){
             int class = bytes[0];
             y.vals[i+b*10000][class] = 1;
             for(j = 0; j < X.cols; ++j){

--- a/darknet_ros/src/go.c
+++ b/darknet_ros/src/go.c
@@ -443,7 +443,7 @@ void engine_go(char *filename, char *weightfile, int multi)
     char *one = calloc(91, sizeof(char));
     char *two = calloc(91, sizeof(char));
     int passed = 0;
-    while(1) {
+    while(1){
         char buff[256];
         int id = 0;
         int has_id = (scanf("%d", &id) == 1);
@@ -463,7 +463,7 @@ void engine_go(char *filename, char *weightfile, int multi)
             printf("=%s 1.0\n\n", ids);
         } else if (!strcmp(buff, "known_command")){
             char comm[256];
-           if( scanf("%s", comm)==1);{
+            if(scanf("%s", comm)==1){
             int known = (!strcmp(comm, "protocol_version") ||
                     !strcmp(comm, "name") ||
                     !strcmp(comm, "version") ||
@@ -562,7 +562,7 @@ void engine_go(char *filename, char *weightfile, int multi)
             //print_board(board, 1, 0);
         } else if (!strcmp(buff, "final_status_list")){
             char type[256];
-           if( scanf("%s", type)==1){
+            if( scanf("%s", type)==1){
             fprintf(stderr, "final_status\n");
             char *line = fgetl(stdin);
             free(line);
@@ -593,7 +593,8 @@ void engine_go(char *filename, char *weightfile, int multi)
                 }
             } else {
                 printf("?%s unknown command\n\n", ids);
-            }}
+            }
+        }
         } else {
             char *line = fgetl(stdin);
             free(line);

--- a/darknet_ros/src/go.c
+++ b/darknet_ros/src/go.c
@@ -1,4 +1,3 @@
-#pragma GCC diagnostic ignored "-Wunused-result"
 #include "network.h"
 #include "utils.h"
 #include "parser.h"
@@ -444,11 +443,13 @@ void engine_go(char *filename, char *weightfile, int multi)
     char *one = calloc(91, sizeof(char));
     char *two = calloc(91, sizeof(char));
     int passed = 0;
-    while(1){
+    while(1) {
         char buff[256];
         int id = 0;
         int has_id = (scanf("%d", &id) == 1);
-        scanf("%s", buff);
+        if (scanf("%s", buff)==1)
+        {
+
         if (feof(stdin)) break;
         char ids[256];
         sprintf(ids, "%d", id);
@@ -462,7 +463,7 @@ void engine_go(char *filename, char *weightfile, int multi)
             printf("=%s 1.0\n\n", ids);
         } else if (!strcmp(buff, "known_command")){
             char comm[256];
-            scanf("%s", comm);
+           if( scanf("%s", comm)==1);{
             int known = (!strcmp(comm, "protocol_version") ||
                     !strcmp(comm, "name") ||
                     !strcmp(comm, "version") ||
@@ -476,31 +477,32 @@ void engine_go(char *filename, char *weightfile, int multi)
                     !strcmp(comm, "play") ||
                     !strcmp(comm, "genmove"));
             if(known) printf("=%s true\n\n", ids);
-            else printf("=%s false\n\n", ids);
+            else printf("=%s false\n\n", ids);}
         } else if (!strcmp(buff, "list_commands")){
             printf("=%s protocol_version\nname\nversion\nknown_command\nlist_commands\nquit\nboardsize\nclear_board\nkomi\nplay\ngenmove\nfinal_status_list\n\n", ids);
         } else if (!strcmp(buff, "quit")){
             break;
         } else if (!strcmp(buff, "boardsize")){
             int boardsize = 0;
-            scanf("%d", &boardsize);
+            if (scanf("%d", &boardsize)==1){
             //fprintf(stderr, "%d\n", boardsize);
             if(boardsize != 19){
                 printf("?%s unacceptable size\n\n", ids);
             } else {
                 printf("=%s \n\n", ids);
             }
+        }
         } else if (!strcmp(buff, "clear_board")){
             passed = 0;
             memset(board, 0, 19*19*sizeof(float));
             printf("=%s \n\n", ids);
         } else if (!strcmp(buff, "komi")){
             float komi = 0;
-            scanf("%f", &komi);
-            printf("=%s \n\n", ids);
+            if (scanf("%f", &komi)==1){
+            printf("=%s \n\n", ids);}
         } else if (!strcmp(buff, "play")){
             char color[256];
-            scanf("%s ", color);
+            if(scanf("%s ", color)){
             char c;
             int r;
             int count = scanf("%c%d", &c, &r);
@@ -529,10 +531,10 @@ void engine_go(char *filename, char *weightfile, int multi)
             board_to_string(one, board);
 
             printf("=%s \n\n", ids);
-            print_board(board, 1, 0);
+            print_board(board, 1, 0);}
         } else if (!strcmp(buff, "genmove")){
             char color[256];
-            scanf("%s", color);
+            if(scanf("%s", color)==1){
             int player = (color[0] == 'b' || color[0] == 'B') ? 1 : -1;
 
             int index = generate_move(net, player, board, multi, .1, .7, two, 1);
@@ -554,12 +556,13 @@ void engine_go(char *filename, char *weightfile, int multi)
                 printf("=%s %c%d\n\n", ids, 'A' + col, row);
                 print_board(board, 1, 0);
             }
+        }
 
         } else if (!strcmp(buff, "p")){
             //print_board(board, 1, 0);
         } else if (!strcmp(buff, "final_status_list")){
             char type[256];
-            scanf("%s", type);
+           if( scanf("%s", type)==1){
             fprintf(stderr, "final_status\n");
             char *line = fgetl(stdin);
             free(line);
@@ -590,7 +593,7 @@ void engine_go(char *filename, char *weightfile, int multi)
                 }
             } else {
                 printf("?%s unknown command\n\n", ids);
-            }
+            }}
         } else {
             char *line = fgetl(stdin);
             free(line);
@@ -598,6 +601,7 @@ void engine_go(char *filename, char *weightfile, int multi)
         }
         fflush(stdout);
         fflush(stderr);
+    }
     }
 }
 

--- a/darknet_ros/src/go.c
+++ b/darknet_ros/src/go.c
@@ -1,3 +1,4 @@
+#pragma GCC diagnostic ignored "-Wunused-result"
 #include "network.h"
 #include "utils.h"
 #include "parser.h"

--- a/darknet_ros/src/image.c
+++ b/darknet_ros/src/image.c
@@ -1,3 +1,6 @@
+#pragma GCC diagnostic ignored "-Wunused-result"
+#pragma GCC diagnostic ignored "-Wimplicit-function-declaration"
+#pragma GCC diagnostic ignored "-Wint-conversion"
 #include "image.h"
 #include "utils.h"
 #include "blas.h"

--- a/darknet_ros/src/image.c
+++ b/darknet_ros/src/image.c
@@ -1,6 +1,3 @@
-#pragma GCC diagnostic ignored "-Wunused-result"
-#pragma GCC diagnostic ignored "-Wimplicit-function-declaration"
-#pragma GCC diagnostic ignored "-Wint-conversion"
 #include "image.h"
 #include "utils.h"
 #include "blas.h"
@@ -14,7 +11,6 @@
 #include "stb_image_write.h"
 
 #ifdef OPENCV
-// #include <opencv2/core/core_c.h>
 #include "opencv2/highgui/highgui_c.h"
 #include "opencv2/imgproc/imgproc_c.h"
 #include "opencv2/videoio/videoio_c.h"

--- a/darknet_ros/src/parser.c
+++ b/darknet_ros/src/parser.c
@@ -946,11 +946,11 @@ void load_convolutional_weights_binary(layer l, FILE *fp)
     int i, j, k;
     for(i = 0; i < l.n; ++i){
         float mean = 0;
-       if( fread(&mean, sizeof(float), 1, fp) ==1){
+        if( fread(&mean, sizeof(float), 1, fp) ==1){
         for(j = 0; j < size/8; ++j){
             int index = i*size + j*8;
             unsigned char c = 0;
-          if (fread(&c, sizeof(char), 1, fp)==1){
+            if (fread(&c, sizeof(char), 1, fp)==1){
             for(k = 0; k < 8; ++k){
                 if (j*8 + k >= size) break;
                 l.weights[index + k] = (c & 1<<k) ? mean : -mean;
@@ -973,8 +973,8 @@ void load_convolutional_weights(layer l, FILE *fp)
         //return;
     }
     int num = l.n*l.c*l.size*l.size;
-   int b = fread(l.biases, sizeof(float), l.n, fp);
-   assert (b==1);
+    int b = fread(l.biases, sizeof(float), l.n, fp);
+    assert (b==1);
     if (l.batch_normalize && (!l.dontloadscales)){
         int s = fread(l.scales, sizeof(float), l.n, fp);
         int r_m = fread(l.rolling_mean, sizeof(float), l.n, fp);
@@ -996,8 +996,8 @@ void load_convolutional_weights(layer l, FILE *fp)
             fill_cpu(l.n, 0, l.rolling_variance, 1);
         }
     }
-   int w = fread(l.weights, sizeof(float), num, fp);
-   assert (w==1);
+    int w = fread(l.weights, sizeof(float), num, fp);
+    assert (w==1);
     if(l.adam){
         int  m = fread(l.m, sizeof(float), num, fp);
         int v = fread(l.v, sizeof(float), num, fp);

--- a/darknet_ros/src/parser.c
+++ b/darknet_ros/src/parser.c
@@ -1,3 +1,4 @@
+#pragma GCC diagnostic ignored "-Wunused-result"
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>

--- a/darknet_ros/src/rnn.c
+++ b/darknet_ros/src/rnn.c
@@ -1,4 +1,3 @@
-#pragma GCC diagnostic ignored "-Wunused-result"
 #include "network.h"
 #include "cost_layer.h"
 #include "utils.h"
@@ -143,7 +142,8 @@ void train_char_rnn(char *cfgfile, char *weightfile, char *filename, int clear, 
         fseek(fp, 0, SEEK_SET);
 
         text = calloc(size+1, sizeof(char));
-        fread(text, 1, size, fp);
+        int t = fread(text, 1, size, fp);
+        assert(t ==1);
         fclose(fp);
     }
 

--- a/darknet_ros/src/rnn.c
+++ b/darknet_ros/src/rnn.c
@@ -1,3 +1,4 @@
+#pragma GCC diagnostic ignored "-Wunused-result"
 #include "network.h"
 #include "cost_layer.h"
 #include "utils.h"

--- a/darknet_ros/src/utils.c
+++ b/darknet_ros/src/utils.c
@@ -1,4 +1,3 @@
-#pragma GCC diagnostic ignored "-Wunused-result"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -278,8 +277,8 @@ char *fgetl(FILE *fp)
         }
         size_t readsize = size-curr;
         if(readsize > INT_MAX) readsize = INT_MAX-1;
-        fgets(&line[curr], readsize, fp);
-        curr = strlen(line);
+        if(fgets(&line[curr], readsize, fp)){
+        curr = strlen(line);}
     }
     if(line[curr-1] == '\n') line[curr-1] = '\0';
 

--- a/darknet_ros/src/utils.c
+++ b/darknet_ros/src/utils.c
@@ -1,3 +1,4 @@
+#pragma GCC diagnostic ignored "-Wunused-result"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
Modified few files to suppress warning while compiling darknet. These warnings started to show up after moving the header files around to make darknet compatible with OpenCV 3. 